### PR TITLE
Remove square and power-of-two default flags of PVRTexTool

### DIFF
--- a/lib/argsHandler.ts
+++ b/lib/argsHandler.ts
@@ -88,6 +88,20 @@ const createParserArguments = (): ICLIArgs => {
     required: false,
   });
 
+  // Resize square flag
+  parser.addArgument(['-rs', '--square'], {
+    choices: ['no', '-', '+'],
+    help: 'Force the texture into a square (default: +)',
+    required: false,
+  });
+
+  // Resize power of two flag
+  parser.addArgument(['-rp', '--pot'], {
+    choices: ['no', '-', '+'],
+    help: 'Force the texture into power of two dimensions (default: +)',
+    required: false,
+  });
+
   // Arbitrary flags to pass on to specific tool
   parser.addArgument(['-f', '--flags'], {
     help: 'Any flags you want to directly pass to the compression tool',
@@ -112,6 +126,8 @@ export interface ICLIArgs {
   quality: string;
   mipmap?: boolean;
   flipY?: boolean;
+  square?: string;
+  pot?: string;
   flags?: string[] | null;
   verbose?: boolean;
 }

--- a/lib/compressors/compressWithPVRTexTool.ts
+++ b/lib/compressors/compressWithPVRTexTool.ts
@@ -67,12 +67,16 @@ export const compressWithPVRTexTool = (args: ICLIArgs): Promise<any> => {
     '-f',
     `${args.compression}`,
     `-q`,
-    `${args.quality}`,
-    `-square`,
-    `+`,
-    `-pot`,
-    `+`,
+    `${args.quality}`,    
   ];
+
+  if (args.square !== 'no') {
+    flagMapping.push('-square', args.square || '+');
+  }
+
+  if (args.pot !== 'no') {
+    flagMapping.push('-pot', args.pot || '+');
+  }
 
   if (args.mipmap) {
     const { width } = getImageSize(args.input);


### PR DESCRIPTION
Textures which are compressed by PVRTexTool are forced to square and power-of-two. Unfortunately, there is no way to override this behaviour. This fix removes default flags. So, if a user wants to use square and power-of-two textures, he can use `--flags`.