### PR TITLE
Use reject instead of throw in promise executor

### DIFF
--- a/lib/compressors/spawnProcess.ts
+++ b/lib/compressors/spawnProcess.ts
@@ -25,7 +25,7 @@ export const spawnProcess = (
   const combinedFlags = [...flagMapping, ...toolFlags];
 
   return new Promise(
-    (resolve): void => {
+    (resolve, reject): void => {
       if (args.verbose) {
         console.log(`Using flags: ${combinedFlags}`);
       }
@@ -47,7 +47,7 @@ export const spawnProcess = (
 
       child.once('exit', (code: number) => {
         if (code !== 0) {
-          throw new Error(`Compression tool exited with error code ${code}`);
+          reject(new Error(`Compression tool exited with error code ${code}`));
         } else {
           resolve();
         }


### PR DESCRIPTION
A promise executor should pass an error via reject instead of throwing it, otherwise it's impossible for the caller to catch the error (since the executor is running asynchronously) and the app will terminate.