### PR TITLE
Include types in package.json to avoid typescript error

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "CLI tool for texture compression using ASTC, ETC, PVRTC and S3TC in a KTX container.",
   "main": "dist/cli/lib/index.js",
+  "types": "dist/types/lib/index.d.ts",
   "scripts": {
     "start": "tsc -w",
     "lint": "tslint --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",


### PR DESCRIPTION
If the package 'texture-compressor' is imported via typescript:
```
import { pack } from "texture-compressor";
```

The typescript compiler (v3.6.4) will output the following error:
```
error TS7016: Could not find a declaration file for module 'texture-compressor'. 'node_modules/texture-compressor/dist/cli/lib/index.js' implicitly has an 'any' type.
  Try `npm install @types/texture-compressor` if it exists or add a new declaration (.d.ts) file containing `declare module 'texture-compressor';`
```

Because the `package.json` hasn't told typescript where to find the type declarations, which this PR fixes.